### PR TITLE
fix: filter internal prompts from chat capture observations

### DIFF
--- a/src/hooks/chat-capture.ts
+++ b/src/hooks/chat-capture.ts
@@ -11,6 +11,24 @@ const MAX_NARRATIVE_LENGTH = 2000;
 const MAX_TITLE_CONTENT_LENGTH = 60;
 
 /**
+ * Patterns that identify internal open-mem prompts injected into the chat
+ * stream. These should NOT be captured as user observations because they are
+ * implementation artifacts, not user intent.
+ */
+const INTERNAL_PROMPT_PATTERNS: RegExp[] = [
+	// The observation extraction prompt (compressor → chat.message)
+	/^\s*<task>\s*\n?\s*Analyze the following tool output and extract a structured observation/i,
+	// The session summarization prompt
+	/^\s*<task>\s*\n?\s*Summarize the following coding session based on its observations/i,
+	// The conflict evaluation prompt
+	/^\s*<conflict_evaluation>/i,
+	// The entity extraction prompt
+	/^\s*<entity_extraction>/i,
+	// The reranking prompt
+	/^\s*<rerank_request>/i,
+];
+
+/**
  * Type guard: checks whether a value is an object with a string `text` property.
  */
 function hasTextProperty(value: unknown): value is { text: string } {
@@ -76,6 +94,9 @@ export function persistChatMessage(input: ChatCaptureInput): boolean {
 	// Strip private blocks and redact sensitive content before any processing
 	const processedText = redactSensitive(stripPrivateBlocks(text), sensitivePatterns);
 	if (processedText.length < MIN_MESSAGE_LENGTH) return false;
+
+	// Filter out internal open-mem prompts that leak into the chat stream
+	if (INTERNAL_PROMPT_PATTERNS.some((p) => p.test(processedText))) return false;
 
 	sessions.getOrCreate(sessionId, projectPath);
 

--- a/tests/hooks/chat-capture.test.ts
+++ b/tests/hooks/chat-capture.test.ts
@@ -232,6 +232,100 @@ describe("createChatCaptureHook", () => {
 		expect((data.filesModified as string[]).length).toBe(0);
 	});
 
+	test("filters out internal observation extraction prompts", async () => {
+		const observations = makeMockObservations();
+		const sessions = makeMockSessions();
+		const hook = createChatCaptureHook(observations as never, sessions as never, "/tmp/proj");
+
+		await hook(
+			{ sessionID: "s1" },
+			{
+				message: {},
+				parts: [
+					`<task>
+Analyze the following tool output and extract a structured observation.
+</task>
+
+<tool_name>bash</tool_name>
+
+<tool_output>
+Some tool output here that is definitely long enough to pass the length check
+</tool_output>`,
+				],
+			},
+		);
+
+		expect(observations.calls).toHaveLength(0);
+	});
+
+	test("filters out internal summarization prompts", async () => {
+		const observations = makeMockObservations();
+		const sessions = makeMockSessions();
+		const hook = createChatCaptureHook(observations as never, sessions as never, "/tmp/proj");
+
+		await hook(
+			{ sessionID: "s1" },
+			{
+				message: {},
+				parts: [
+					`<task>
+Summarize the following coding session based on its observations.
+</task>
+
+<session_id>ses_abc123</session_id>
+
+<observations>
+  <obs index="1">
+    <title>Some observation</title>
+  </obs>
+</observations>`,
+				],
+			},
+		);
+
+		expect(observations.calls).toHaveLength(0);
+	});
+
+	test("filters out internal conflict evaluation prompts", async () => {
+		const observations = makeMockObservations();
+		const sessions = makeMockSessions();
+		const hook = createChatCaptureHook(observations as never, sessions as never, "/tmp/proj");
+
+		await hook(
+			{ sessionID: "s1" },
+			{
+				message: {},
+				parts: [
+					`<conflict_evaluation>
+<new_observation>
+  <title>Some title</title>
+</new_observation>
+</conflict_evaluation>`,
+				],
+			},
+		);
+
+		expect(observations.calls).toHaveLength(0);
+	});
+
+	test("does not filter normal user messages that happen to contain XML-like tags", async () => {
+		const observations = makeMockObservations();
+		const sessions = makeMockSessions();
+		const hook = createChatCaptureHook(observations as never, sessions as never, "/tmp/proj");
+
+		await hook(
+			{ sessionID: "s1" },
+			{
+				message: {},
+				parts: [
+					"Please help me debug this HTML issue with <div> tags and also fix the layout",
+				],
+			},
+		);
+
+		expect(observations.calls.find((c) => c.method === "create")).toBeDefined();
+	});
+
 	test("handles mixed string and object parts", async () => {
 		const observations = makeMockObservations();
 		const sessions = makeMockSessions();

--- a/tests/hooks/chat-capture.test.ts
+++ b/tests/hooks/chat-capture.test.ts
@@ -308,6 +308,53 @@ Summarize the following coding session based on its observations.
 		expect(observations.calls).toHaveLength(0);
 	});
 
+	test("filters out internal entity extraction prompts", async () => {
+		const observations = makeMockObservations();
+		const sessions = makeMockSessions();
+		const hook = createChatCaptureHook(observations as never, sessions as never, "/tmp/proj");
+
+		await hook(
+			{ sessionID: "s1" },
+			{
+				message: {},
+				parts: [
+					`<entity_extraction>
+<observation>
+  <title>Some title</title>
+  <type>discovery</type>
+  <narrative>Some narrative text about entities and relationships</narrative>
+</observation>
+</entity_extraction>`,
+				],
+			},
+		);
+
+		expect(observations.calls).toHaveLength(0);
+	});
+
+	test("filters out internal reranking prompts", async () => {
+		const observations = makeMockObservations();
+		const sessions = makeMockSessions();
+		const hook = createChatCaptureHook(observations as never, sessions as never, "/tmp/proj");
+
+		await hook(
+			{ sessionID: "s1" },
+			{
+				message: {},
+				parts: [
+					`<rerank_request>
+<query>some search query about authentication patterns</query>
+<candidates>
+  <candidate index="0"><title>Auth middleware</title></candidate>
+</candidates>
+</rerank_request>`,
+				],
+			},
+		);
+
+		expect(observations.calls).toHaveLength(0);
+	});
+
 	test("does not filter normal user messages that happen to contain XML-like tags", async () => {
 		const observations = makeMockObservations();
 		const sessions = makeMockSessions();


### PR DESCRIPTION
## Problem

Closes #20

The `chat-capture` hook (`chat.message`) unconditionally stored **all** user messages as observations, including open-mem internal prompts that leak into the chat stream.

In one project database, **2330 out of 4710 observations (49%)** were garbage `"User request: <task>\nAnalyze the following tool output..."` entries — internal extraction prompts, not user intent.

These garbage observations were injected back into context via `true_memory_context`, causing:
- **Token waste**: ~2KB per garbage observation
- **Stale directive injection**: Old `[search-mode]`, `[analyze-mode]` directives re-injected into new sessions
- **Progressive degradation**: Gets worse over time as more garbage accumulates

## Root Cause

open-mem injects internal prompts (observation extraction, summarization, conflict evaluation, entity extraction, reranking) into the chat stream. The `chat-capture` hook sees these as user messages and stores them as observations with `title="User request: <task>..."`.

## Fix

Add `INTERNAL_PROMPT_PATTERNS` — a list of regex patterns matching all 5 internal prompt templates — to `chat-capture.ts`. Before creating an observation, the text is tested against these patterns and rejected if it matches.

**Changes:**
- `src/hooks/chat-capture.ts`: +18 lines (pattern definitions + filter check)
- `tests/hooks/chat-capture.test.ts`: +97 lines (4 new test cases)

## Testing

```
✓ filters out internal observation extraction prompts
✓ filters out internal summarization prompts
✓ filters out internal conflict evaluation prompts
✓ does not filter normal user messages that happen to contain XML-like tags
✓ All 16 existing tests pass
```

## Workaround for existing databases

For users with existing garbage observations, run:

```sql
UPDATE observations SET deleted_at = datetime('now')
WHERE title LIKE 'User request:%' AND deleted_at IS NULL;
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Internal system prompts are now properly filtered and prevented from being persisted in chat history, ensuring only user-generated content is saved as observations.

* **Tests**
  * Added test coverage for message filtering behavior to validate that internal prompts are correctly excluded while normal user messages are preserved.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/clopca/open-mem/pull/21?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->